### PR TITLE
Rocket.Chat version up

### DIFF
--- a/project/docker-compose.yml
+++ b/project/docker-compose.yml
@@ -200,7 +200,7 @@ services:
 # Rocket.Chat
 #####################################################
   rocketchat:
-    image: rocketchat/rocket.chat:0.28.0
+    image: rocketchat/rocket.chat:0.29.0
     environment:
       - PORT=3000
       - ROOT_URL=http://localhost/portal/rocketchat

--- a/proxy/proxy/config/conf.d/default.conf
+++ b/proxy/proxy/config/conf.d/default.conf
@@ -17,6 +17,12 @@ server {
   location / {
     index index.html;
     root /usr/share/nginx/html;
+
+    # https://github.com/RocketChat/Rocket.Chat/issues/3092
+    # Rocket.Chat用。bugfixまでの仮実装
+    if ($request_uri ~* ^/(tap-i18n|assets)(.*)$) {
+      rewrite ^/(tap-i18n|assets)(.*)$ /portal/rocketchat/$1$2 last;
+    }
   }
 
   #error_page  404              /404.html;


### PR DESCRIPTION
- 0.28.0 -> 0.29.0
- 資材のパスが一部正しくないので、proxy側でルーティング調整
